### PR TITLE
Use `rust-hash` instead of `fxhash`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ byteorder = "1.3"
 itertools = "0.9"
 positioned-io = { package = "positioned-io-preview", version = "0.3" }
 lazy_static = "1.4"
-fxhash = "0.2"
+rustc-hash = "1.1"
 once_cell = "1.1"
 
 [dev-dependencies]

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,5 +1,4 @@
 use bencher::{Bencher, benchmark_group, benchmark_main, black_box};
-use matches::assert_matches;
 
 use shakmaty::Chess;
 use shakmaty::fen::Fen;
@@ -24,7 +23,7 @@ fn bench_probe_wdl(bench: &mut Bencher) {
         .expect("legal position");
 
     bench.iter(|| {
-        assert_matches!(tb.probe_wdl(black_box(&pos)), Ok(Wdl::BlessedLoss));
+        assert!(matches!(tb.probe_wdl(black_box(&pos)), Ok(Wdl::BlessedLoss)));
     });
 }
 

--- a/src/tablebase.rs
+++ b/src/tablebase.rs
@@ -22,7 +22,7 @@ use std::str::FromStr;
 
 use arrayvec::ArrayVec;
 use once_cell::sync::OnceCell;
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use positioned_io::RandomAccessFile;
 
 use shakmaty::{Material, Move, MoveList, Position, Role};


### PR DESCRIPTION
`fxhash` seems not to be maintained anymore `while rustc-hash` is the "official" implementation used by rustc and maintained by rust-lang.

Did a bench just in case (1,6 GHz Intel Core i5-2467M)
before:
test bench_add_directory ... bench: 287,902,510 ns/iter (+/- 137,824,185)
test bench_probe_wdl ... bench: 3,973,610 ns/iter (+/- 2,268,762)
after:
test bench_add_directory ... bench: 271,782,730 ns/iter (+/- 75,746,895)
test bench_probe_wdl ... bench: 4,044,770 ns/iter (+/- 1,577,451)

No perf change at first sight, but the interval confidence is very large