### PR TITLE
Public method for just checking the table

### DIFF
--- a/src/tablebase.rs
+++ b/src/tablebase.rs
@@ -177,6 +177,26 @@ impl<S: Position + Clone + Syzygy> Tablebase<S> {
         self.probe(pos).map(|entry| entry.wdl())
     }
 
+    /// Fetches the [`Wdl`] for a position.
+    ///
+    /// This performs a simple lookup from the tables, as opposed to
+    /// [`probe_wdl`] which will do some extra searching of a position.
+    ///
+    /// # Errors
+    ///
+    /// See [`SyzygyError`] for possible error
+    /// condiitions.
+    pub fn get_wdl(&self, pos: &S) -> SyzygyResult<Wdl> {
+        if pos.board().occupied().count() > S::MAX_PIECES {
+            return Err(SyzygyError::TooManyPieces);
+        }
+        if pos.castles().any() {
+            return Err(SyzygyError::Castling);
+        }
+
+        self.probe_wdl_table(pos)
+    }
+
     /// Probe tables for the [`Dtz`] value of a position.
     ///
     /// Min-maxing the DTZ of the available moves guarantees achieving the


### PR DESCRIPTION
The case where this is useful, is if I just want to use syzygy for evaluation, not for search. I wish to skip the ab probing that the probe_XXX methods do, and simply perform a wdl lookup.